### PR TITLE
add 12Boti repository

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -8,6 +8,10 @@
             "github-contact": "1235467",
             "url": "https://github.com/1235467/nurpkgs"
         },
+        "12Boti": {
+            "github-contact": "12Boti",
+            "url": "https://github.com/12Boti/nur"
+        },
         "7mind": {
             "github-contact": "7mind",
             "url": "https://github.com/7mind/7mind-nix"


### PR DESCRIPTION
The following points apply when adding a new repository to repos.json

- [X] I ran `./bin/nur format-manifest` after updating `repos.json` (We will use the same script in github actions to make sure we keep the format consistent)
- [X] By including this repository in NUR I give permission to license the
content under the MIT license.

Clarification where license should apply:
The license above does not apply to the packages built by the Nix Packages
collection, merely to the package descriptions (i.e., Nix expressions, build
scripts, etc.). It also might not apply to patches included in Nixpkgs, which
may be derivative works of the packages to which they apply. The aforementioned
artifacts are all covered by the licenses of the respective packages.
